### PR TITLE
Set up log rotation for the automation agent

### DIFF
--- a/manifests/automation_agent.pp
+++ b/manifests/automation_agent.pp
@@ -41,6 +41,13 @@ class mongodb_ops_manager::automation_agent(
     require => Package['mongodb-mms-automation-agent-manager.x86_64'],
     notify  => Service['mongodb-mms-automation-agent']
   }
+  
+  file { '/etc/logrotate.d/mongodb-mms-automation-agent':
+    content => template('mongodb_ops_manager/automation-agent-logrotate.conf.erb'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644'
+  }
 
   service { 'mongodb-mms-automation-agent':
     ensure    => running,

--- a/templates/automation-agent-logrotate.conf.erb
+++ b/templates/automation-agent-logrotate.conf.erb
@@ -1,0 +1,10 @@
+/var/log/mongodb-mms-automation/automation-agent*.log {
+        daily
+        rotate 10
+        missingok
+        notifempty
+        compress
+        delaycompress
+        copytruncate
+        create 644 mongod mongod
+}

--- a/templates/automation-agent.config.erb
+++ b/templates/automation-agent.config.erb
@@ -45,8 +45,8 @@ maxLogFiles=10
 
 #
 # Maximum size in bytes of a log file (before rotating)
-#
-maxLogFileSize=268435456
+# 1073741824 == 2**30 == 1GiB
+maxLogFileSize=1073741824
 
 #
 # URL to proxy all HTTP requests through


### PR DESCRIPTION
Currently MMS rotates the automation agent logfile when it reaches 2**28 bytes, and then just moves it aside without compressing it. Compression doesn't seem to be an option (unlike backup and monitoring agents, which are configured in the UI), so we'll do it using the logrotate utility.